### PR TITLE
Repurpose contains_shit to be logically correct

### DIFF
--- a/wtf/wtf.h
+++ b/wtf/wtf.h
@@ -4,7 +4,8 @@
 
 #define sucks ==nullptr
 #define does_not_suck !=nullptr
-#define contains_shit empty()
+#define contains_shit(X) !(X).empty()
+#define doesnt_contain_shit empty()
 #define then_fuck_it exit(1);
 #define fuck_this_i_am_out return 0
 #define the_finger(x) std::runtime_error(x)


### PR DESCRIPTION
Defining contains_shit as empty() means that contains_shit is technically true when the thing it's used on _doesn't_ contain shit. Also repurposes the original check as doesnt_contain_shit.